### PR TITLE
IOSURFACE_CREATE_OUTSIZE for iOS 12.0 works for iOS 12.1.1 on A8X iPad Air 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# v1ntex
+# v1ntex12
+(adapting v1ntex for iOS 12)
 In the end it wasn't exactly *just* copy&pasting v0rtex and jelbrekTime :o   
 (https://twitter.com/tihmstar/status/1087973240927145984)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # v1ntex12
 (adapting v1ntex for iOS 12)
+
 In the end it wasn't exactly *just* copy&pasting v0rtex and jelbrekTime :o   
 (https://twitter.com/tihmstar/status/1087973240927145984)
 

--- a/v1ntex/exploit.m
+++ b/v1ntex/exploit.m
@@ -34,7 +34,7 @@ const uint32_t IKOT_TASK                = 2;
 
 #define postProgress(prg) [[NSNotificationCenter defaultCenter] postNotificationName: @"JB" object:nil userInfo:@{@"JBProgress": prg}]
 
-#define IOSURFACE_CREATE_OUTSIZE    0xbc8 /* XXX 0x6c8 for iOS 11.0, 0xbc8 for 11.1.2 */
+#define IOSURFACE_CREATE_OUTSIZE    0xdd0 /* XXX 0x6c8 for iOS 11.0, 0xbc8 for 11.1.2,0xdd0 for iOS 12.0 */
 #define OFFSET_TASK_ITK_SELF        0xd8
 #define OFFSET_IOUSERCLIENT_IPC     0x9c
 #define BSDINFO_PID_OFFSET  0x10


### PR DESCRIPTION
I launched __c8f8e07__ commit with set offset for iOS 12.0 on iPad Air 2 (A8X '4k' CPU) running iOS 12.1.1 an it passed until _setValue(0)_ message. So this 0xdd0 offset can possibly work from iOS12.0 to iOS 12.1.1 
KERNEL: Darwin Kernel Version 18.2.0: Mon Nov 12 20:32:02 PST 2018; root:xnu-4903.232.2~1/RELEASE_ARM64_T7001

(ends with panic btw)